### PR TITLE
Adds Deprecation notice to packages.json for command line warnings.

### DIFF
--- a/src/Packagist/WebBundle/Package/SymlinkDumper.php
+++ b/src/Packagist/WebBundle/Package/SymlinkDumper.php
@@ -292,6 +292,7 @@ class SymlinkDumper
             $this->rootFile['notify-batch'] = $this->router->generate('track_download_batch');
             $this->rootFile['providers-url'] = $this->router->generate('home') . 'p/%package%$%hash%.json';
             $this->rootFile['search'] = $this->router->generate('search', array('_format' => 'json')) . '?q=%query%';
+            $this->rootFile['warning'] = 'Drupal Packagist is deprecated, you should use the official Package Repository from Drupal.org instead: (https://www.drupal.org/node/2718229). This site will be available until January 2017';
 
             if ($verbose) {
                 echo 'Dumping individual listings'.PHP_EOL;


### PR DESCRIPTION
Composer will display any warnings on the command line if we provide one (see here: https://github.com/composer/composer/blob/ff4e2ec2191e93e90fb954b699135c561bd2ee42/src/Composer/Repository/ComposerRepository.php#L488-L488).  This will add visibility to the deprecation. I havent tested this, so hopefully it doesnt break any other tests.
